### PR TITLE
Remove @! run()

### DIFF
--- a/src/base_interop.jl
+++ b/src/base_interop.jl
@@ -35,21 +35,6 @@ end
     # could replicate.
 end
 
-# Processes
-
-"""
-    @! run(command, args...)
-
-Run a `command` object asynchronously as in `run(...; wait=false)` and return
-the `Process` object. The process object is bound to the scope of the current
-`@context` and will be waited for with `wait()` when the context exits.
-"""
-@! function Base.run(cmds::Base.AbstractCmd, args...)
-    proc = run(cmds, args..., wait=false)
-    @defer success(proc) || Base.pipeline_error(proc)
-    proc
-end
-
 # Locks
 
 @! function Base.lock(lk::Base.AbstractLock)

--- a/test/base_interop.jl
+++ b/test/base_interop.jl
@@ -63,20 +63,6 @@
         @test pwd() == oldpath
     end
 
-    @testset "run()" begin
-        in_io = Pipe()
-        out_io = IOBuffer()
-        local proc
-        @context begin
-            proc = @! run(pipeline(`$(Base.julia_cmd()) -e 'write(stdout, readline(stdin))'`,
-                                   stdout=out_io, stdin=in_io))
-            @test !process_exited(proc)
-            println(in_io, "hi")
-        end
-        @test process_exited(proc)
-        @test String(take!(out_io)) == "hi"
-    end
-
     @testset "lock()" begin
         lk = ReentrantLock()
         @context begin


### PR DESCRIPTION
It's not clear that calling `wait` on the result of `run` has the
correct semantics - unlike other resources, the cleanup of the process
may require nontrivial bespoke communication with the caller.

So let's just remove this for now, perhaps in the future we can have a
more complete story for concurrency in this package.