### PR TITLE
Fix stdio redirections for the Julia 1.7 API  breakage

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,7 +1,10 @@
 name: CI
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - main
+    tags: '*'
+  pull_request:
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
@@ -10,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.5'
+          - '1.6'
           - '1'
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ julia = "1.5"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 
 [targets]
-test = ["Test"]
+test = ["Test", "Compat"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ResourceContexts"
 uuid = "8d208092-d35c-4dd3-a0d7-8325f9cce6b4"
 authors = ["Chris Foster <chris42f@gmail.com> and contributors"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"

--- a/test/base_interop.jl
+++ b/test/base_interop.jl
@@ -97,11 +97,7 @@
             seek(io, 0)
             stderr_result = readline(io)
         end
-        if VERSION < v"1.7-DEV"
-            @test stderr_result == "hi"
-        else
-            @test_broken stderr_result == "hi"
-        end
+        @test stderr_result == "hi"
 
         stdin_result = nothing
         @context begin
@@ -112,11 +108,7 @@
             @! redirect_stdin(io)
             stdin_result = readline()
         end
-        if VERSION < v"1.7-DEV"
-            @test stdin_result == "hi"
-        else
-            @test_broken stdin_result == "hi"
-        end
+        @test stdin_result == "hi"
 
         @test orig_stdin == stdin
         @test orig_stdout == stdout

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using ResourceContexts
 using Test
 using Logging
+using Compat
 
 # Use of @! to pass context to resource creation function
 @! function foo(x, label)
@@ -35,7 +36,7 @@ end
             @defer error("B")
         end
     catch exc
-        stack = Base.catch_stack()
+        stack = current_exceptions()
         @test stack[1][1] == ErrorException("B")
         @test stack[2][1] == ErrorException("A")
     end
@@ -92,7 +93,7 @@ end
         end
     catch e
         @test e isa TaskFailedException
-        first(Base.catch_stack(e.task))[1]
+        first(current_exceptions(e.task))[1]
     end == ErrorException("Oops1")
 
     @test try
@@ -101,7 +102,7 @@ end
         end
     catch e
         @test e isa TaskFailedException
-        first(Base.catch_stack(e.task))[1]
+        first(current_exceptions(e.task))[1]
     end == ErrorException("Oops2")
 end
 


### PR DESCRIPTION
Base.redirect_stdout etc are no longer generic functions, so it's not
possible to overload these anymore. Instead it's necessary to overload
the function object Base.RedirectStdStream.

XRef:
* https://github.com/JuliaLang/julia/pull/39132
* https://github.com/JuliaLang/julia/pull/37978

And solutions in other packages
* https://github.com/JuliaDiff/ChainRules.jl/pull/358
* https://github.com/JuliaLang/IJulia.jl/pull/989